### PR TITLE
#22842 - Create a different temp file for each import

### DIFF
--- a/abc_import.qml
+++ b/abc_import.qml
@@ -117,6 +117,11 @@ MuseScore {
                 if (request.readyState == XMLHttpRequest.DONE) {
                     var response = request.responseText
                     //console.log("responseText : " + response)
+                    var noFile = 2;
+                    while (myFile.exists()) {
+                        myFile.source = myFile.tempPath() + "/my_file" + noFile +".xml"
+                        noFile++;
+                    }
                     myFile.write(response)
                     readScore(myFile.source)
                         Qt.quit()


### PR DESCRIPTION
Solve the issue "#22842 First ABC import overwritten by the second" by incrementing the temp file name to avoid overwriting the previously imported tune. 

This update depend on the MuseScore pull request https://github.com/musescore/MuseScore/pull/532 to work. That pull request adds the exists() function to the plugin FileIO framework.
